### PR TITLE
ObjectState abstract class

### DIFF
--- a/carstate.cpp
+++ b/carstate.cpp
@@ -156,7 +156,7 @@ void CarState::simulationStep(double dt_ms, PosType usePosType)
         currentPosition.setY(currentPosition.getY() + sin(-yawRad) * drivenDistance);
     }
 
-    currentPosition.setTime(QTime::currentTime().addSecs(-QDateTime::currentDateTime().offsetFromUtc()).msecsSinceStartOfDay());
+	currentPosition.setTime(QTime::currentTime().addSecs(-QDateTime::currentDateTime().offsetFromUtc()));
     setPosition(currentPosition);
 }
 

--- a/carstate.cpp
+++ b/carstate.cpp
@@ -11,7 +11,7 @@ CarState::CarState(int id, Qt::GlobalColor color) : VehicleState(id, color)
 void CarState::draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected)
 {
     PosPoint pos = getPosition();
-//        LocPoint pos_gps = VehicleState->getLocationGps();
+    //        LocPoint pos_gps = VehicleState->getLocationGps();
 
     const double car_len = getLength() * 1000.0;
     const double car_w = getWidth() * 1000.0;
@@ -19,8 +19,8 @@ void CarState::draw(QPainter &painter, const QTransform &drawTrans, const QTrans
 
     double x = pos.getX() * 1000.0;
     double y = pos.getY() * 1000.0;
-//        double x_gps = pos_gps.getX() * 1000.0;
-//        double y_gps = pos_gps.getY() * 1000.0;
+    //        double x_gps = pos_gps.getX() * 1000.0;
+    //        double y_gps = pos_gps.getY() * 1000.0;
     painter.setTransform(drawTrans);
 
     QColor col_wheels;
@@ -29,7 +29,7 @@ void CarState::draw(QPainter &painter, const QTransform &drawTrans, const QTrans
     QColor col_sigma = Qt::red;
     QColor col_hull = getColor();
     QColor col_center = Qt::blue;
-//        QColor col_gps = Qt::magenta;
+    //        QColor col_gps = Qt::magenta;
 
     if (isSelected) {
         col_wheels = Qt::black;
@@ -108,7 +108,7 @@ void CarState::draw(QPainter &painter, const QTransform &drawTrans, const QTrans
     if (getDrawStatusText()) {
         QPointF statusTextPoint;
         QRectF statusTextRect;
-		QString statusText = getName() + "\nID: " +QString::number(getId());
+        QString statusText = getName() + "\nID: " +QString::number(getId());
 
         statusTextPoint.setX(x + car_w + car_len * ((cos(getPosition().getYaw() * (M_PI/180.0)) + 1) / 3));
         statusTextPoint.setY(y - car_w / 2);
@@ -116,7 +116,7 @@ void CarState::draw(QPainter &painter, const QTransform &drawTrans, const QTrans
         painter.setTransform(txtTrans);
         statusTextPoint = drawTrans.map(statusTextPoint);
         statusTextRect.setCoords(statusTextPoint.x(), statusTextPoint.y(),
-                           statusTextPoint.x() + 400, statusTextPoint.y() + 100);
+                                 statusTextPoint.x() + 400, statusTextPoint.y() + 100);
         painter.drawText(statusTextRect, statusText);
     }
 }
@@ -156,13 +156,13 @@ void CarState::simulationStep(double dt_ms, PosType usePosType)
         currentPosition.setY(currentPosition.getY() + sin(-yawRad) * drivenDistance);
     }
 
-	currentPosition.setTime(QTime::currentTime().addSecs(-QDateTime::currentDateTime().offsetFromUtc()));
+    currentPosition.setTime(QTime::currentTime().addSecs(-QDateTime::currentDateTime().offsetFromUtc()));
     setPosition(currentPosition);
 }
 
 double CarState::getAxisDistance() const
 {
-	return fabs(mAxisDistance) < 0.001 ? 0.8*getLength() : mAxisDistance;
+    return fabs(mAxisDistance) < 0.001 ? 0.8*getLength() : mAxisDistance;
 }
 
 void CarState::setAxisDistance(double axisDistance)
@@ -172,24 +172,24 @@ void CarState::setAxisDistance(double axisDistance)
 
 double CarState::getRearOverhang() const
 {
-	return mRearOverhang;
+    return mRearOverhang;
 }
 
 void CarState::setRearOverhang(double rearOverhang)
 {
-	//TODO:: Set this using objectPhysics/displacement/xd/value which is currently not sent to SafetyZone
-	mRearOverhang = rearOverhang;
+    //TODO:: Set this using objectPhysics/displacement/xd/value which is currently not sent to SafetyZone
+    mRearOverhang = rearOverhang;
 }
 
 double CarState::getFrontOverhang() const
 {
-	return mFrontOverhang;
+    return mFrontOverhang;
 }
 
 void CarState::setFrontOverhang(double frontOverhang)
 {
-	//TODO:: Set this using objectPhysics/displacement/xd/value which is currently not sent to SafetyZone
-	mFrontOverhang = frontOverhang;
+    //TODO:: Set this using objectPhysics/displacement/xd/value which is currently not sent to SafetyZone
+    mFrontOverhang = frontOverhang;
 }
 
 double CarState::getSteering() const
@@ -205,11 +205,11 @@ void CarState::setSteering(double value)
 }
 
 void CarState::setMaxSteeringAngle(double steeringAngle_rad) {
-	mMaxSteeringAngle = fabs(steeringAngle_rad);
+    mMaxSteeringAngle = fabs(steeringAngle_rad);
 }
 
 void CarState::setMinTurnRadiusRear(double minTurnRadius_m) {
-	mMinTurnRadiusRear = fabs(minTurnRadius_m);
+    mMinTurnRadiusRear = fabs(minTurnRadius_m);
 }
 
 double CarState::getBrakingDistance() const {

--- a/carstate.h
+++ b/carstate.h
@@ -22,15 +22,15 @@ public:
 
     // Static state
     double getAxisDistance() const;
-	void setAxisDistance(double axisDistance);
-	double getRearOverhang() const;
-	void setRearOverhang(double rearOverhang);
-	double getFrontOverhang() const;
-	void setFrontOverhang(double frontOverhang);
+    void setAxisDistance(double axisDistance);
+    double getRearOverhang() const;
+    void setRearOverhang(double rearOverhang);
+    double getFrontOverhang() const;
+    void setFrontOverhang(double frontOverhang);
 
-	inline double getMaxSteeringAngle() const { return mMaxSteeringAngle < M_PI/180.0 ? M_PI/4.0 : mMaxSteeringAngle; } // 45° assumed if unset
-	void setMaxSteeringAngle(double steeringAngle_rad);
-	void setMinTurnRadiusRear(double minTurnRadius_m);
+    inline double getMaxSteeringAngle() const { return mMaxSteeringAngle < M_PI/180.0 ? M_PI/4.0 : mMaxSteeringAngle; } // 45° assumed if unset
+    void setMaxSteeringAngle(double steeringAngle_rad);
+    void setMinTurnRadiusRear(double minTurnRadius_m);
 
     // Dynamic state
     double getSteering() const;
@@ -46,8 +46,8 @@ public:
     inline double getMinTurnRadiusRear() const { return qMax(qMin(getAxisDistance() / tanf(getMaxSteeringAngle()), mMinTurnRadiusRear), pow(getSpeed(), 2)/(0.21*9.81)); }
 
 private:
-	double mRearOverhang = 0.0; //[m]
-	double mFrontOverhang = 0.0; //[m]
+    double mRearOverhang = 0.0; //[m]
+    double mFrontOverhang = 0.0; //[m]
     double mAxisDistance; // [m]
     double mSteering = 0.0; // [-1.0:1.0]
     double mMaxSteeringAngle = 0.0; // [rad]

--- a/coordinatetransforms.h
+++ b/coordinatetransforms.h
@@ -80,17 +80,17 @@ static inline void createEnuMatrix(double lat, double lon, double *enuMat)
     enuMat[8] = sa;
 
     // NED
-//    enuMat[0] = -sa * co;
-//    enuMat[1] = -sa * so;
-//    enuMat[2] = ca;
+    //    enuMat[0] = -sa * co;
+    //    enuMat[1] = -sa * so;
+    //    enuMat[2] = ca;
 
-//    enuMat[3] = -so;
-//    enuMat[4] = co;
-//    enuMat[5] = 0.0;
+    //    enuMat[3] = -so;
+    //    enuMat[4] = co;
+    //    enuMat[5] = 0.0;
 
-//    enuMat[6] = -ca * co;
-//    enuMat[7] = -ca * so;
-//    enuMat[8] = -sa;
+    //    enuMat[6] = -ca * co;
+    //    enuMat[7] = -ca * so;
+    //    enuMat[8] = -sa;
 }
 
 static inline xyz_t llhToEnu(const llh_t &iLlh, const llh_t &llh)

--- a/gnss/ubloxrover.cpp
+++ b/gnss/ubloxrover.cpp
@@ -305,7 +305,7 @@ void UbloxRover::updateAHRS(const ubx_esf_meas &meas)
             newYaw -= 360.0;
         tmppos.setYaw(newYaw);
 
-        tmppos.setTime(QTime::currentTime().addSecs(-QDateTime::currentDateTime().offsetFromUtc()).msecsSinceStartOfDay()); // TODO: can meas.time_tag be mapped to UTC/iTOW?
+        tmppos.setTime(QTime::currentTime().addSecs(-QDateTime::currentDateTime().offsetFromUtc())); // TODO: can meas.time_tag be mapped to UTC/iTOW?
         mVehicleState->setPosition(tmppos);
 
         emit updatedIMUOrientation(mVehicleState);
@@ -346,7 +346,7 @@ void UbloxRover::updateGNSSPositionAndYaw(const ubx_nav_pvt &pvt)
             gnssPos.setYaw(-atan2(xyz.y - lastXyz.y, xyz.x - lastXyz.x) * 180.0 / M_PI);
 
         // Time and speed
-        gnssPos.setTime((pvt.i_tow % ms_per_day) - leapSeconds_ms);
+        gnssPos.setTime(QTime::fromMSecsSinceStartOfDay((pvt.i_tow % ms_per_day) - leapSeconds_ms));
 //        qDebug() << "UbloxRover, gnssPos.getTime() - msSinceTodayUTC:" << QTime::currentTime().addSecs(-QDateTime::currentDateTime().offsetFromUtc()).msecsSinceStartOfDay() - gnssPos.getTime();
         gnssPos.setSpeed(pvt.g_speed);
 

--- a/legacy/packetinterfacetcpserver.cpp
+++ b/legacy/packetinterfacetcpserver.cpp
@@ -185,7 +185,7 @@ PacketInterfaceTCPServer::PacketInterfaceTCPServer(QObject *parent) : QObject(pa
                         newPoint.setY(packetData.vbPopFrontDouble32(1e4));
                         newPoint.setHeight(packetData.vbPopFrontDouble32(1e4));
                         newPoint.setSpeed(packetData.vbPopFrontDouble32(1e6));
-                        newPoint.setTime(packetData.vbPopFrontInt32());
+                        newPoint.setTime(QTime::fromMSecsSinceStartOfDay(packetData.vbPopFrontInt32()));
                         newPoint.setAttributes(packetData.vbPopFrontUint32());
                         mWaypointFollower->addWaypoint(newPoint);
                     }

--- a/mapwidget.cpp
+++ b/mapwidget.cpp
@@ -271,27 +271,22 @@ void MapWidget::addVehicle(QSharedPointer<VehicleState> vehicleState)
 
 bool MapWidget::removeObject(int objectID)
 {
-	QMutableListIterator<QSharedPointer<ObjectState>> i(mObjectStateList);
-	while (i.hasNext()) {
-		if (i.next()->getId() == objectID) {
-			i.remove();
-			return true;
-		}
-	}
-	return false;
+    const auto oldSize = mObjectStateList.size();
+    std::remove_if(mObjectStateList.begin(), mObjectStateList.end(),
+                   [objectID](const QSharedPointer<ObjectState>& st){
+        return st->getId() == objectID;
+    });
+    return oldSize != mObjectStateList.size();
 }
 
 bool MapWidget::removeVehicle(int vehicleID)
 {
-	QMutableListIterator<QSharedPointer<ObjectState>> i(mObjectStateList);
-    while (i.hasNext()) {
-		if (i.next()->getId() == vehicleID
-				&& i.next().dynamicCast<VehicleState>() != nullptr) {
-            i.remove();
-            return true;
-        }
-    }
-    return false;
+    const auto oldSize = mObjectStateList.size();
+    std::remove_if(mObjectStateList.begin(), mObjectStateList.end(),
+                   [vehicleID](const QSharedPointer<ObjectState>& st){
+        return st->getId() == vehicleID && st.dynamicCast<VehicleState>() != nullptr;
+    });
+    return oldSize != mObjectStateList.size();
 }
 
 void MapWidget::clearObjects()

--- a/mapwidget.cpp
+++ b/mapwidget.cpp
@@ -160,7 +160,7 @@ MapWidget::MapWidget(QWidget *parent) : QWidget(parent)
     xRealPos = 0;
     yRealPos = 0;
     mRoutePointSpeed = 1.0;
-    mRoutePointTime = 0.0;
+	mRoutePointTime = QTime();
     mRoutePointAttributes = 0;
     mAnchorId = 0;
     mAnchorHeight = 1.0;
@@ -374,7 +374,7 @@ void MapWidget::clearTrace()
     update();
 }
 
-void MapWidget::addRoutePoint(double px, double py, double speed, qint32 time)
+void MapWidget::addRoutePoint(double px, double py, double speed, QTime time)
 {
     PosPoint pos;
     pos.setXY(px, py);
@@ -949,12 +949,12 @@ void MapWidget::setTraceMinSpaceVehicle(double traceMinSpaceVehicle)
     mTraceMinSpaceVehicle = traceMinSpaceVehicle;
 }
 
-qint32 MapWidget::getRoutePointTime() const
+QTime MapWidget::getRoutePointTime() const
 {
     return mRoutePointTime;
 }
 
-void MapWidget::setRoutePointTime(const qint32 &routePointTime)
+void MapWidget::setRoutePointTime(const QTime &routePointTime)
 {
     mRoutePointTime = routePointTime;
 }
@@ -1740,7 +1740,7 @@ void MapWidget::drawRoute(QPainter& painter, QTransform drawTrans, QTransform tx
 
         // Draw text only for selected route
         if (isSelected && drawAnnotations) {
-            QTime t = QTime::fromMSecsSinceStartOfDay(route[i].getTime());
+			QTime t = route[i].getTime();
             pointLabel.sprintf("P: %d %s\n"
                         "%.1f km/h\n"
                         "%02d:%02d:%02d:%03d\n"

--- a/mapwidget.cpp
+++ b/mapwidget.cpp
@@ -160,7 +160,7 @@ MapWidget::MapWidget(QWidget *parent) : QWidget(parent)
     xRealPos = 0;
     yRealPos = 0;
     mRoutePointSpeed = 1.0;
-	mRoutePointTime = QTime();
+    mRoutePointTime = QTime();
     mRoutePointAttributes = 0;
     mAnchorId = 0;
     mAnchorHeight = 1.0;
@@ -201,9 +201,9 @@ MapWidget::MapWidget(QWidget *parent) : QWidget(parent)
     mRefLlh = {57.78100308, 12.76925422, 253.76};
 
     // RISE RTK base station
-//    mRefLat = 57.71495867;
-//    mRefLon = 12.89134921;
-//    mRefHeight = 219.0;
+    //    mRefLat = 57.71495867;
+    //    mRefLon = 12.89134921;
+    //    mRefHeight = 219.0;
 
     // Hardcoded for now
     mOsm->setCacheDir("osm_tiles");
@@ -249,9 +249,9 @@ MapWidget::MapWidget(QWidget *parent) : QWidget(parent)
 
 QSharedPointer<VehicleState> MapWidget::getVehicleState(int vehicleID)
 {
-	for (int i = 0;i < mObjectStateList.size();i++) {
-		if (mObjectStateList[i]->getId() == vehicleID) {
-			return mObjectStateList[i].dynamicCast<VehicleState>();
+    for (int i = 0;i < mObjectStateList.size();i++) {
+        if (mObjectStateList[i]->getId() == vehicleID) {
+            return mObjectStateList[i].dynamicCast<VehicleState>();
         }
     }
 
@@ -260,13 +260,13 @@ QSharedPointer<VehicleState> MapWidget::getVehicleState(int vehicleID)
 
 void MapWidget::addObject(QSharedPointer<ObjectState> objectState)
 {
-	mObjectStateList.append(objectState);
-	connect(objectState.get(), &ObjectState::positionUpdated, this, &MapWidget::objectPositionUpdated);
+    mObjectStateList.append(objectState);
+    connect(objectState.get(), &ObjectState::positionUpdated, this, &MapWidget::objectPositionUpdated);
 }
 void MapWidget::addVehicle(QSharedPointer<VehicleState> vehicleState)
 {
-	mObjectStateList.append(vehicleState.dynamicCast<ObjectState>());
-	connect(vehicleState.get(), &VehicleState::positionUpdated, this, &MapWidget::objectPositionUpdated);
+    mObjectStateList.append(vehicleState.dynamicCast<ObjectState>());
+    connect(vehicleState.get(), &VehicleState::positionUpdated, this, &MapWidget::objectPositionUpdated);
 }
 
 bool MapWidget::removeObject(int objectID)
@@ -291,7 +291,7 @@ bool MapWidget::removeVehicle(int vehicleID)
 
 void MapWidget::clearObjects()
 {
-	mObjectStateList.clear();
+    mObjectStateList.clear();
 }
 
 void MapWidget::clearVehicles()
@@ -653,13 +653,13 @@ void MapWidget::mousePressEvent(QMouseEvent *e)
     if (ctrl) {
         if (e->buttons() & Qt::LeftButton) {
             if (mSelectedObject >= 0) {
-				for (int i = 0;i < mObjectStateList.size();i++) {
-					QSharedPointer<VehicleState> vehicleState = mObjectStateList[i].dynamicCast<VehicleState>();
+                for (int i = 0;i < mObjectStateList.size();i++) {
+                    QSharedPointer<VehicleState> vehicleState = mObjectStateList[i].dynamicCast<VehicleState>();
                     if (vehicleState->getId() == mSelectedObject) {
-						PosPoint pos = vehicleState->getPosition();
+                        PosPoint pos = vehicleState->getPosition();
                         QPoint p = getMousePosRelative();
                         pos.setXY(p.x() / 1000.0, p.y() / 1000.0);
-						vehicleState->setPosition(pos);
+                        vehicleState->setPosition(pos);
                         emit posSet(mSelectedObject, pos);
                     }
                 }
@@ -775,14 +775,14 @@ void MapWidget::wheelEvent(QWheelEvent *e)
     }
 
     if (ctrl && mSelectedObject >= 0) {
-		for (int i = 0;i < mObjectStateList.size();i++) {
-			QSharedPointer<VehicleState> vehicleState = mObjectStateList[i].dynamicCast<VehicleState>();
+        for (int i = 0;i < mObjectStateList.size();i++) {
+            QSharedPointer<VehicleState> vehicleState = mObjectStateList[i].dynamicCast<VehicleState>();
             if (vehicleState->getId() == mSelectedObject) {
-				PosPoint pos = vehicleState->getPosition();
+                PosPoint pos = vehicleState->getPosition();
                 double angle = pos.getYaw() + (double)e->angleDelta().y() * 0.0005;
                 normalizeAngleRad(angle);
                 pos.setYaw(angle);
-				vehicleState->setPosition(pos);
+                vehicleState->setPosition(pos);
                 emit posSet(mSelectedObject, pos);
                 update();
             }
@@ -857,19 +857,19 @@ bool MapWidget::event(QEvent *event)
 
 QList<QSharedPointer<ObjectState> > MapWidget::getObjectStateList() const
 {
-	return mObjectStateList;
+    return mObjectStateList;
 }
 
 QList<QSharedPointer<VehicleState> > MapWidget::getVehicleStateList() const
 {
-	QList<QSharedPointer<VehicleState>> retval;
-	for (const auto& obj : mObjectStateList) {
-		auto veh = obj.dynamicCast<VehicleState>();
-		if (veh != nullptr) {
-			retval.append(veh);
-		}
-	}
-	return retval;
+    QList<QSharedPointer<VehicleState>> retval;
+    for (const auto& obj : mObjectStateList) {
+        auto veh = obj.dynamicCast<VehicleState>();
+        if (veh != nullptr) {
+            retval.append(veh);
+        }
+    }
+    return retval;
 }
 
 quint32 MapWidget::getRoutePointAttributes() const
@@ -1167,8 +1167,8 @@ int MapWidget::drawInfoPoints(QPainter &painter, const QList<PosPoint> &pts,
                 last_visible = i;
             }
 
-//            painter.setBrush(ip.getColor());
-//            painter.setPen(ip.getColor());
+            //            painter.setBrush(ip.getColor());
+            //            painter.setPen(ip.getColor());
             painter.drawEllipse(p2, ip.getRadius(), ip.getRadius());
 
             drawn++;
@@ -1579,25 +1579,25 @@ QPair<int, int> MapWidget::drawInfoTraces(QPainter& painter, QTransform drawTran
         for (int i = 0;i < itNow.size();i++) {
             PosPoint ip = itNow[i];
 
-//            if (mInfoTraceNow != in) {
-//                ip.setColor(Qt::gray);
-//            }
+            //            if (mInfoTraceNow != in) {
+            //                ip.setColor(Qt::gray);
+            //            }
 
-//            if (ip.getColor() == Qt::darkGreen || ip.getColor() == Qt::green) {
-//                pts_green.append(ip);
-//            } else if (ip.getColor() == Qt::darkRed || ip.getColor() == Qt::red) {
-//                pts_red.append(ip);
-//            } else {
-                pts_other.append(ip);
-//            }
+            //            if (ip.getColor() == Qt::darkGreen || ip.getColor() == Qt::green) {
+            //                pts_green.append(ip);
+            //            } else if (ip.getColor() == Qt::darkRed || ip.getColor() == Qt::red) {
+            //                pts_red.append(ip);
+            //            } else {
+            pts_other.append(ip);
+            //            }
         }
 
-//        info_points += drawInfoPoints(painter, pts_green, drawTrans, txtTrans,
-//                                      viewRect_mm, info_min_dist);
+        //        info_points += drawInfoPoints(painter, pts_green, drawTrans, txtTrans,
+        //                                      viewRect_mm, info_min_dist);
         info_points += drawInfoPoints(painter, pts_other, drawTrans, txtTrans,
                                       viewRect_mm, info_min_dist);
-//        info_points += drawInfoPoints(painter, pts_red, drawTrans, txtTrans,
-//                                      viewRect_mm, info_min_dist);
+        //        info_points += drawInfoPoints(painter, pts_red, drawTrans, txtTrans,
+        //                                      viewRect_mm, info_min_dist);
     }
 
     // Draw point closest to mouse pointer
@@ -1620,7 +1620,7 @@ QPair<int, int> MapWidget::drawInfoTraces(QPainter& painter, QTransform drawTran
         pen.setColor(Qt::black);
         painter.setPen(pen);
         textRectangle.setCoords(textPos.x(), textPos.y() - 20,
-                           textPos.x() + 500, textPos.y() + 500);
+                                textPos.x() + 500, textPos.y() + 500);
         painter.drawText(textRectangle, Qt::AlignTop | Qt::AlignLeft, mClosestInfo.getInfo());
     }
 
@@ -1634,7 +1634,7 @@ void MapWidget::drawOSMTiles(QPainter& painter, QTransform drawTrans, double vie
         const llh_t &iLlh = mRefLlh;
 
         mOsmZoomLevel = (int)round(log(mScaleFactor * mOsmRes * 100000000.0 *
-                                        cos(iLlh.latitude * M_PI / 180.0)) / log(2.0));
+                                       cos(iLlh.latitude * M_PI / 180.0)) / log(2.0));
         if (mOsmZoomLevel > mOsmMaxZoomLevel) {
             mOsmZoomLevel = mOsmMaxZoomLevel;
         } else if (mOsmZoomLevel < 0) {
@@ -1719,7 +1719,7 @@ void MapWidget::drawRoute(QPainter& painter, QTransform drawTrans, QTransform tx
 
         painter.setOpacity(0.7);
         painter.drawLine(route.at(i-1).getX() * 1000.0, route.at(i-1).getY() * 1000.0,
-                route.at(i).getX() * 1000.0, route.at(i).getY() * 1000.0);
+                         route.at(i).getX() * 1000.0, route.at(i).getY() * 1000.0);
         painter.setOpacity(1.0);
     }
 
@@ -1769,15 +1769,15 @@ void MapWidget::drawRoute(QPainter& painter, QTransform drawTrans, QTransform tx
 
         // Draw text only for selected route
         if (isSelected && drawAnnotations) {
-			QTime t = route[i].getTime();
+            QTime t = route[i].getTime();
             pointLabel.sprintf("P: %d %s\n"
-                        "%.1f km/h\n"
-                        "%02d:%02d:%02d:%03d\n"
-                        "A: %08X",
-                        i, ((i == 0) ? "- start" : ((i == route.size()-1) ? "- end" : "")),
-                        route[i].getSpeed() * 3.6,
-                        t.hour(), t.minute(), t.second(), t.msec(),
-                        route[i].getAttributes());
+                               "%.1f km/h\n"
+                               "%02d:%02d:%02d:%03d\n"
+                               "A: %08X",
+                               i, ((i == 0) ? "- start" : ((i == route.size()-1) ? "- end" : "")),
+                               route[i].getSpeed() * 3.6,
+                               t.hour(), t.minute(), t.second(), t.msec(),
+                               route[i].getAttributes());
 
             pointLabelPos.setX(p.x() + 10 / scaleFactor);
             pointLabelPos.setY(p.y());
@@ -1786,7 +1786,7 @@ void MapWidget::drawRoute(QPainter& painter, QTransform drawTrans, QTransform tx
             pen.setColor(Qt::black);
             painter.setPen(pen);
             pointLabelRectangle.setCoords(pointLabelPos.x(), pointLabelPos.y() - 20,
-                               pointLabelPos.x() + 200, pointLabelPos.y() + 60);
+                                          pointLabelPos.x() + 200, pointLabelPos.y() + 60);
             painter.drawText(pointLabelRectangle, pointLabel);
         } else {
             pointLabel.sprintf("%d", routeID);
@@ -1797,7 +1797,7 @@ void MapWidget::drawRoute(QPainter& painter, QTransform drawTrans, QTransform tx
             pen.setColor(Qt::black);
             painter.setPen(pen);
             pointLabelRectangle.setCoords(pointLabelPos.x() - 20, pointLabelPos.y() - 20,
-                               pointLabelPos.x() + 20, pointLabelPos.y() + 20);
+                                          pointLabelPos.x() + 20, pointLabelPos.y() + 20);
             painter.drawText(pointLabelRectangle, Qt::AlignCenter, pointLabel);
         }
     }
@@ -1828,17 +1828,17 @@ void MapWidget::drawAnchor(QPainter &painter, QTransform drawTrans, QTransform t
 
     // Print data
     anchorLabel.sprintf("Anchor %d\n"
-                "Pos    : (%.3f, %.3f)\n"
-                "Height : %.2f m",
-                anchor.getId(),
-                anchor.getX(), anchor.getY(),
-                anchor.getHeight());
+                        "Pos    : (%.3f, %.3f)\n"
+                        "Height : %.2f m",
+                        anchor.getId(),
+                        anchor.getX(), anchor.getY(),
+                        anchor.getHeight());
     anchorLabelPos.setX(x);
     anchorLabelPos.setY(y);
     painter.setTransform(txtTrans);
     anchorLabelPos = drawTrans.map(anchorLabelPos);
     anchorLabelRectangle.setCoords(anchorLabelPos.x() + 15, anchorLabelPos.y() - 20,
-                       anchorLabelPos.x() + 500, anchorLabelPos.y() + 500);
+                                   anchorLabelPos.x() + 500, anchorLabelPos.y() + 500);
     painter.drawText(anchorLabelRectangle, anchorLabel);
 }
 
@@ -1975,10 +1975,10 @@ void MapWidget::paint(QPainter &painter, int width, int height, bool highQuality
 
     // Optionally follow a vehicle
     if (mFollowObjectId >= 0) {
-		for (int i = 0;i < mObjectStateList.size();i++) {
-			QSharedPointer<VehicleState> vehicleState = mObjectStateList[i].dynamicCast<VehicleState>();
+        for (int i = 0;i < mObjectStateList.size();i++) {
+            QSharedPointer<VehicleState> vehicleState = mObjectStateList[i].dynamicCast<VehicleState>();
             if (vehicleState->getId() == mFollowObjectId) {
-				PosPoint followLoc = vehicleState->getPosition();
+                PosPoint followLoc = vehicleState->getPosition();
                 mXOffset = -followLoc.getX() * 1000.0 * mScaleFactor;
                 mYOffset = -followLoc.getY() * 1000.0 * mScaleFactor;
             }
@@ -2090,7 +2090,7 @@ void MapWidget::paint(QPainter &painter, int width, int height, bool highQuality
 
     // Draw vehicles
     painter.setPen(QPen(QPalette::Foreground));
-	for(const auto& obj : mObjectStateList)
+    for(const auto& obj : mObjectStateList)
         obj->draw(painter, drawTrans, txtTrans, obj->getId() == mSelectedObject);
 
     painter.setPen(QPen(QPalette::Foreground));
@@ -2109,8 +2109,8 @@ void MapWidget::updateTraces()
 {
     // Store trace for the selected object
     if (mTraceObject >= 0) {
-		for (int i = 0;i < mObjectStateList.size();i++) {
-			QSharedPointer<ObjectState> objectState = mObjectStateList[i];
+        for (int i = 0;i < mObjectStateList.size();i++) {
+            QSharedPointer<ObjectState> objectState = mObjectStateList[i];
             if (objectState->getId() == mTraceObject) {
                 if (mObjectTrace.isEmpty()) {
                     mObjectTrace.append(objectState->getPosition());
@@ -2118,20 +2118,20 @@ void MapWidget::updateTraces()
                 if (mObjectTrace.last().getDistanceTo(objectState->getPosition()) > mTraceMinSpaceObject) {
                     mObjectTrace.append(objectState->getPosition());
                 }
-//                // GPS trace
-//                if (mVehicleTraceGps.isEmpty()) {
-//                    mVehicleTraceGps.append(VehicleState->getLocationGps());
-//                }
-//                if (mVehicleTraceGps.last().getDistanceTo(VehicleState->getLocationGps()) > mTraceMinSpaceGps) {
-//                    mVehicleTraceGps.append(VehicleState->getLocationGps());
-//                }
-//                // UWB trace
-//                if (mVehicleTraceUwb.isEmpty()) {
-//                    mVehicleTraceUwb.append(VehicleState->getLocationUwb());
-//                }
-//                if (mVehicleTraceUwb.last().getDistanceTo(VehicleState->getLocationUwb()) > mTraceMinSpaceVehicle) {
-//                    mVehicleTraceUwb.append(VehicleState->getLocationUwb());
-//                }
+                //                // GPS trace
+                //                if (mVehicleTraceGps.isEmpty()) {
+                //                    mVehicleTraceGps.append(VehicleState->getLocationGps());
+                //                }
+                //                if (mVehicleTraceGps.last().getDistanceTo(VehicleState->getLocationGps()) > mTraceMinSpaceGps) {
+                //                    mVehicleTraceGps.append(VehicleState->getLocationGps());
+                //                }
+                //                // UWB trace
+                //                if (mVehicleTraceUwb.isEmpty()) {
+                //                    mVehicleTraceUwb.append(VehicleState->getLocationUwb());
+                //                }
+                //                if (mVehicleTraceUwb.last().getDistanceTo(VehicleState->getLocationUwb()) > mTraceMinSpaceVehicle) {
+                //                    mVehicleTraceUwb.append(VehicleState->getLocationUwb());
+                //                }
             }
         }
     }

--- a/mapwidget.cpp
+++ b/mapwidget.cpp
@@ -301,7 +301,7 @@ void MapWidget::clearObjects()
 
 void MapWidget::clearVehicles()
 {
-	clearObjects(); // TODO
+    clearObjects(); // TODO only remove vehicle type objects
 }
 
 PosPoint *MapWidget::getAnchor(int anchorId)

--- a/mapwidget.h
+++ b/mapwidget.h
@@ -35,6 +35,7 @@
 
 #include "pospoint.h"
 #include "vehiclestate.h"
+#include "objectstate.h"
 #include "osmclient.h"
 #include "coordinatetransforms.h"
 
@@ -61,13 +62,17 @@ public:
     } RoutePointType;
 
     explicit MapWidget(QWidget *parent = 0);
+	QSharedPointer<ObjectState> getObjectState(int objectID);
     QSharedPointer<VehicleState> getVehicleState(int vehicleID);
     void setFollowVehicle(int vehicleID);
     void setTraceVehicle(int vehicleID);
     void setSelectedVehicle(int vehicleID);
-    void addVehicle(QSharedPointer<VehicleState> vehicleState);
-    bool removeVehicle(int vehicleID);
+	void addObject(QSharedPointer<ObjectState> objectState);
+	void addVehicle(QSharedPointer<VehicleState> vehicleState);
+	bool removeObject(int objectID);
+	bool removeVehicle(int vehicleID);
     void clearVehicles();
+	void clearObjects();
     PosPoint* getAnchor(int anchorId);
     void addAnchor(const PosPoint &anchor);
     bool removeAnchor(int anchorId);
@@ -165,6 +170,7 @@ public:
     quint32 getRoutePointAttributes() const;
     void setRoutePointAttributes(const quint32 &routePointAttributes);
 
+	QList<QSharedPointer<ObjectState> > getObjectStateList() const;
     QList<QSharedPointer<VehicleState> > getVehicleStateList() const;
 
     double drawGrid(QPainter &painter, QTransform drawTrans, QTransform txtTrans, double gridWidth, double gridHeight);
@@ -190,7 +196,7 @@ private slots:
     void tileReady(OsmTile tile);
     void errorGetTile(QString reason);
     void timerSlot();
-    void vehiclePositionUpdated();
+	void objectPositionUpdated();
 
 protected:
     void paintEvent(QPaintEvent *event) override;
@@ -201,7 +207,7 @@ protected:
     bool event(QEvent *event) override;
 
 private:
-    QList<QSharedPointer<VehicleState>> mVehicleStateList;
+	QList<QSharedPointer<ObjectState>> mObjectStateList;
     QVector<PosPoint> mVehicleTrace;
     QVector<PosPoint> mVehicleTraceGNSS;
     QVector<PosPoint> mVehicleTraceUwb;

--- a/mapwidget.h
+++ b/mapwidget.h
@@ -64,9 +64,9 @@ public:
     explicit MapWidget(QWidget *parent = 0);
 	QSharedPointer<ObjectState> getObjectState(int objectID);
     QSharedPointer<VehicleState> getVehicleState(int vehicleID);
-    void setFollowVehicle(int vehicleID);
-    void setTraceVehicle(int vehicleID);
-    void setSelectedVehicle(int vehicleID);
+    void setFollowObject(int objectID);
+    void setTraceObject(int objectID);
+    void setSelectedObject(int objectID);
 	void addObject(QSharedPointer<ObjectState> objectState);
 	void addVehicle(QSharedPointer<VehicleState> vehicleState);
 	bool removeObject(int objectID);
@@ -137,8 +137,8 @@ public:
 	QTime getRoutePointTime() const;
 	void setRoutePointTime(const QTime& routePointTime);
 
-    double getTraceMinSpaceVehicle() const;
-    void setTraceMinSpaceVehicle(double traceMinSpaceVehicle);
+    double getTraceMinSpaceObject() const;
+    void setTraceMinSpaceObject(double traceMinSpaceObject);
 
     double getTraceMinSpaceGps() const;
     void setTraceMinSpaceGps(double traceMinSpaceGps);
@@ -208,9 +208,9 @@ protected:
 
 private:
 	QList<QSharedPointer<ObjectState>> mObjectStateList;
-    QVector<PosPoint> mVehicleTrace;
-    QVector<PosPoint> mVehicleTraceGNSS;
-    QVector<PosPoint> mVehicleTraceUwb;
+    QVector<PosPoint> mObjectTrace;
+    QVector<PosPoint> mObjectTraceGNSS;
+    QVector<PosPoint> mObjectTraceUwb;
     QList<PosPoint> mAnchors;
     QList<QList<PosPoint> > mRoutes;
     QList<QList<PosPoint> > mInfoTraces;
@@ -226,9 +226,9 @@ private:
     double mYOffset;
     int mMouseLastX;
     int mMouseLastY;
-    int mFollowVehicleId;
-    int mTraceVehicle;
-    int mSelectedVehicle;
+    int mFollowObjectId;
+    int mTraceObject;
+    int mSelectedObject;
     double xRealPos;
     double yRealPos;
     bool mAntialiasDrawings;
@@ -247,7 +247,7 @@ private:
     int mAnchorSelected;
     int mRouteNow;
     int mInfoTraceNow;
-    double mTraceMinSpaceVehicle;
+    double mTraceMinSpaceObject;
     double mTraceMinSpaceGps;
     QList<QPixmap> mPixmaps;
     bool mAnchorMode;

--- a/mapwidget.h
+++ b/mapwidget.h
@@ -80,7 +80,7 @@ public:
     void setYOffset(double offset);
     void moveView(double px, double py);
     void clearTrace();
-    void addRoutePoint(double px, double py, double speed = 0.0, qint32 time = 0);
+	void addRoutePoint(double px, double py, double speed = 0.0, QTime time = QTime());
     QList<PosPoint> getRoute(int ind = -1);
     QList<QList<PosPoint> > getRoutes();
     void setRoute(const QList<PosPoint> &route);
@@ -129,8 +129,8 @@ public:
     int getRouteNow() const;
     void setRouteNow(int routeNow);
 
-    qint32 getRoutePointTime() const;
-    void setRoutePointTime(const qint32 &routePointTime);
+	QTime getRoutePointTime() const;
+	void setRoutePointTime(const QTime& routePointTime);
 
     double getTraceMinSpaceVehicle() const;
     void setTraceMinSpaceVehicle(double traceMinSpaceVehicle);
@@ -210,7 +210,7 @@ private:
     QList<QList<PosPoint> > mInfoTraces;
     QList<PosPoint> mVisibleInfoTracePoints;
     double mRoutePointSpeed;
-    qint32 mRoutePointTime;
+	QTime mRoutePointTime;
     quint32 mRoutePointAttributes;
     qint32 mAnchorId;
     double mAnchorHeight;

--- a/mapwidget.h
+++ b/mapwidget.h
@@ -62,17 +62,17 @@ public:
     } RoutePointType;
 
     explicit MapWidget(QWidget *parent = 0);
-	QSharedPointer<ObjectState> getObjectState(int objectID);
+    QSharedPointer<ObjectState> getObjectState(int objectID);
     QSharedPointer<VehicleState> getVehicleState(int vehicleID);
     void setFollowObject(int objectID);
     void setTraceObject(int objectID);
     void setSelectedObject(int objectID);
-	void addObject(QSharedPointer<ObjectState> objectState);
-	void addVehicle(QSharedPointer<VehicleState> vehicleState);
-	bool removeObject(int objectID);
-	bool removeVehicle(int vehicleID);
+    void addObject(QSharedPointer<ObjectState> objectState);
+    void addVehicle(QSharedPointer<VehicleState> vehicleState);
+    bool removeObject(int objectID);
+    bool removeVehicle(int vehicleID);
     void clearVehicles();
-	void clearObjects();
+    void clearObjects();
     PosPoint* getAnchor(int anchorId);
     void addAnchor(const PosPoint &anchor);
     bool removeAnchor(int anchorId);
@@ -85,7 +85,7 @@ public:
     void setYOffset(double offset);
     void moveView(double px, double py);
     void clearTrace();
-	void addRoutePoint(double px, double py, double speed = 0.0, QTime time = QTime());
+    void addRoutePoint(double px, double py, double speed = 0.0, QTime time = QTime());
     QList<PosPoint> getRoute(int ind = -1);
     QList<QList<PosPoint> > getRoutes();
     void setRoute(const QList<PosPoint> &route);
@@ -134,8 +134,8 @@ public:
     int getRouteNow() const;
     void setRouteNow(int routeNow);
 
-	QTime getRoutePointTime() const;
-	void setRoutePointTime(const QTime& routePointTime);
+    QTime getRoutePointTime() const;
+    void setRoutePointTime(const QTime& routePointTime);
 
     double getTraceMinSpaceObject() const;
     void setTraceMinSpaceObject(double traceMinSpaceObject);
@@ -170,7 +170,7 @@ public:
     quint32 getRoutePointAttributes() const;
     void setRoutePointAttributes(const quint32 &routePointAttributes);
 
-	QList<QSharedPointer<ObjectState> > getObjectStateList() const;
+    QList<QSharedPointer<ObjectState> > getObjectStateList() const;
     QList<QSharedPointer<VehicleState> > getVehicleStateList() const;
 
     double drawGrid(QPainter &painter, QTransform drawTrans, QTransform txtTrans, double gridWidth, double gridHeight);
@@ -196,7 +196,7 @@ private slots:
     void tileReady(OsmTile tile);
     void errorGetTile(QString reason);
     void timerSlot();
-	void objectPositionUpdated();
+    void objectPositionUpdated();
 
 protected:
     void paintEvent(QPaintEvent *event) override;
@@ -207,7 +207,7 @@ protected:
     bool event(QEvent *event) override;
 
 private:
-	QList<QSharedPointer<ObjectState>> mObjectStateList;
+    QList<QSharedPointer<ObjectState>> mObjectStateList;
     QVector<PosPoint> mObjectTrace;
     QVector<PosPoint> mObjectTraceGNSS;
     QVector<PosPoint> mObjectTraceUwb;
@@ -216,7 +216,7 @@ private:
     QList<QList<PosPoint> > mInfoTraces;
     QList<PosPoint> mVisibleInfoTracePoints;
     double mRoutePointSpeed;
-	QTime mRoutePointTime;
+    QTime mRoutePointTime;
     quint32 mRoutePointAttributes;
     qint32 mAnchorId;
     double mAnchorHeight;
@@ -261,7 +261,7 @@ private:
 
     void updateClosestInfoPoint();
     int drawInfoPoints(QPainter &painter, const QList<PosPoint> &pts,
-                        QTransform drawTrans, QTransform txtTrans,
+                       QTransform drawTrans, QTransform txtTrans,
                        const QRectF& viewRect_mm,
                        double min_dist);
     int getClosestPoint(PosPoint p, QList<PosPoint> points, double &dist);

--- a/objectstate.cpp
+++ b/objectstate.cpp
@@ -1,0 +1,67 @@
+/*
+	Copyright 2012 Benjamin Vedder	benjamin@vedder.se
+			  2020 Marvin Damschen  marvin.damschen@ri.se
+			  2021 Lukas Wikander	lukas.wikander@astazero.com
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+	*/
+
+#include "objectstate.h"
+#include <QDebug>
+
+ObjectState::ObjectState(ObjectID_t id, Qt::GlobalColor color)
+{
+	setId(id, true);
+	setColor(color);
+}
+
+void ObjectState::setId(int id, bool changeName)
+{
+	mId = id;
+	if (changeName) {
+		mName = "";
+		mName.sprintf("Vehicle %d", mId);
+	}
+}
+
+
+void ObjectState::setPosition(PosPoint &point)
+{
+	mPosition = point;
+	emit positionUpdated();
+}
+
+double ObjectState::getSpeed() const
+{
+	return static_cast<double>(mVelocity.length());
+}
+
+void ObjectState::setSpeed(double value)
+{
+	if (mVelocity.isNull()) {
+		mVelocity.setX(1.0);
+	}
+	mVelocity.normalize();
+	mVelocity *= static_cast<float>(value);
+}
+
+void ObjectState::setDrawStatusText(bool drawStatusText)
+{
+	mDrawStatusText = drawStatusText;
+}
+
+bool ObjectState::getDrawStatusText() const
+{
+	return mDrawStatusText;
+}

--- a/objectstate.cpp
+++ b/objectstate.cpp
@@ -44,16 +44,12 @@ void ObjectState::setPosition(PosPoint &point)
 
 double ObjectState::getSpeed() const
 {
-    return static_cast<double>(mVelocity.length());
+    return mSpeed;
 }
 
 void ObjectState::setSpeed(double value)
 {
-    if (mVelocity.isNull()) {
-        mVelocity.setX(1.0);
-    }
-    mVelocity.normalize();
-    mVelocity *= static_cast<float>(value);
+    mSpeed = value;
 }
 
 void ObjectState::setDrawStatusText(bool drawStatusText)

--- a/objectstate.cpp
+++ b/objectstate.cpp
@@ -42,16 +42,6 @@ void ObjectState::setPosition(PosPoint &point)
     emit positionUpdated();
 }
 
-double ObjectState::getSpeed() const
-{
-    return mSpeed;
-}
-
-void ObjectState::setSpeed(double value)
-{
-    mSpeed = value;
-}
-
 void ObjectState::setDrawStatusText(bool drawStatusText)
 {
     mDrawStatusText = drawStatusText;

--- a/objectstate.cpp
+++ b/objectstate.cpp
@@ -1,67 +1,67 @@
 /*
-	Copyright 2012 Benjamin Vedder	benjamin@vedder.se
-			  2020 Marvin Damschen  marvin.damschen@ri.se
-			  2021 Lukas Wikander	lukas.wikander@astazero.com
+    Copyright 2012 Benjamin Vedder	benjamin@vedder.se
+              2020 Marvin Damschen  marvin.damschen@ri.se
+              2021 Lukas Wikander	lukas.wikander@astazero.com
 
-	This program is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	This program is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with this program.  If not, see <http://www.gnu.org/licenses/>.
-	*/
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    */
 
 #include "objectstate.h"
 #include <QDebug>
 
 ObjectState::ObjectState(ObjectID_t id, Qt::GlobalColor color)
 {
-	setId(id, true);
-	setColor(color);
+    setId(id, true);
+    setColor(color);
 }
 
 void ObjectState::setId(int id, bool changeName)
 {
-	mId = id;
-	if (changeName) {
-		mName = "";
-		mName.sprintf("Vehicle %d", mId);
-	}
+    mId = id;
+    if (changeName) {
+        mName = "";
+        mName.sprintf("Vehicle %d", mId);
+    }
 }
 
 
 void ObjectState::setPosition(PosPoint &point)
 {
-	mPosition = point;
-	emit positionUpdated();
+    mPosition = point;
+    emit positionUpdated();
 }
 
 double ObjectState::getSpeed() const
 {
-	return static_cast<double>(mVelocity.length());
+    return static_cast<double>(mVelocity.length());
 }
 
 void ObjectState::setSpeed(double value)
 {
-	if (mVelocity.isNull()) {
-		mVelocity.setX(1.0);
-	}
-	mVelocity.normalize();
-	mVelocity *= static_cast<float>(value);
+    if (mVelocity.isNull()) {
+        mVelocity.setX(1.0);
+    }
+    mVelocity.normalize();
+    mVelocity *= static_cast<float>(value);
 }
 
 void ObjectState::setDrawStatusText(bool drawStatusText)
 {
-	mDrawStatusText = drawStatusText;
+    mDrawStatusText = drawStatusText;
 }
 
 bool ObjectState::getDrawStatusText() const
 {
-	return mDrawStatusText;
+    return mDrawStatusText;
 }

--- a/objectstate.h
+++ b/objectstate.h
@@ -1,0 +1,90 @@
+#ifndef OBJECTSTATE_H
+#define OBJECTSTATE_H
+/*
+	Copyright 2012 Benjamin Vedder	benjamin@vedder.se
+			  2020 Marvin Damschen  marvin.damschen@ri.se
+			  2021 Lukas Wikander	lukas.wikander@astazero.com
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+	*/
+
+
+#include <QObject>
+#include <QVector>
+#include <QVector3D>
+#include <QTime>
+#include <QString>
+#ifdef QT_GUI_LIB
+#include <QPainter>
+#endif
+
+#include "pospoint.h"
+#include <math.h>
+
+class ObjectState : public QObject
+{
+	Q_OBJECT
+public:
+	typedef int ObjectID_t;
+	typedef QVector3D Velocity;
+	typedef QVector3D Acceleration;
+	ObjectState(ObjectID_t id = 0, Qt::GlobalColor color = Qt::red);
+#ifdef QT_GUI_LIB
+	virtual void draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected = true) = 0;
+#endif
+
+	// Static state
+	ObjectID_t getId() const { return mId; }
+	void setId(ObjectID_t id, bool changeName = false);
+	QString getName() const { return mName; }
+	void setName(const QString& name) { mName = name; }
+	Qt::GlobalColor getColor() const { return mColor; }
+	void setColor(const Qt::GlobalColor color) { mColor = color; }
+
+	// Dynamic state
+	virtual PosPoint getPosition() const { return mPosition; }
+	virtual void setPosition(PosPoint &point);
+	virtual QTime getTime() const { return mPosition.getTime(); }
+	virtual void setTime(const QTime &time) { mPosition.setTime(time); }
+	virtual double getSpeed() const;
+	virtual void setSpeed(double value);
+	virtual Velocity getVelocity() const { return mVelocity; }
+	virtual void setVelocity(const Velocity &velocity) { mVelocity = velocity; }
+	virtual Acceleration getAcceleration() const { return mAcceleration; }
+	virtual void setAcceleration(const Acceleration &acceleration) { mAcceleration = acceleration; }
+
+	void setDrawStatusText(bool drawStatusText);
+	bool getDrawStatusText() const;
+
+	virtual void simulationStep(double dt_ms, PosType usePosType = PosType::simulated) = 0; // Take current state and simulate step forward for dt_ms milliseconds, update state accordingly
+
+signals:
+	void positionUpdated();
+
+private:
+	// Static state
+	ObjectID_t mId;
+	QString mName;
+	Qt::GlobalColor mColor;
+	bool mDrawStatusText = true;
+
+protected:
+	// Dynamic state
+	PosPoint mPosition;
+	Velocity mVelocity = {0.0, 0.0, 0.0}; // [m/s]
+	Acceleration mAcceleration = {0.0, 0.0, 0.0}; // [m/s²]
+};
+
+
+#endif // OBJECTSTATE_H

--- a/objectstate.h
+++ b/objectstate.h
@@ -56,8 +56,8 @@ public:
     virtual void setPosition(PosPoint &point);
     virtual QTime getTime() const { return mPosition.getTime(); }
     virtual void setTime(const QTime &time) { mPosition.setTime(time); }
-    virtual double getSpeed() const;
-    virtual void setSpeed(double value);
+    virtual double getSpeed() const { return mSpeed; }
+    virtual void setSpeed(double value) { mSpeed = value; }
     virtual Velocity getVelocity() const { return mVelocity; }
     virtual void setVelocity(const Velocity &velocity) { mVelocity = velocity; }
     virtual Acceleration getAcceleration() const { return mAcceleration; }

--- a/objectstate.h
+++ b/objectstate.h
@@ -1,23 +1,23 @@
 #ifndef OBJECTSTATE_H
 #define OBJECTSTATE_H
 /*
-	Copyright 2012 Benjamin Vedder	benjamin@vedder.se
-			  2020 Marvin Damschen  marvin.damschen@ri.se
-			  2021 Lukas Wikander	lukas.wikander@astazero.com
+    Copyright 2012 Benjamin Vedder	benjamin@vedder.se
+              2020 Marvin Damschen  marvin.damschen@ri.se
+              2021 Lukas Wikander	lukas.wikander@astazero.com
 
-	This program is free software: you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation, either version 3 of the License, or
-	(at your option) any later version.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-	This program is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY; without even the implied warranty of
-	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	GNU General Public License for more details.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-	You should have received a copy of the GNU General Public License
-	along with this program.  If not, see <http://www.gnu.org/licenses/>.
-	*/
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    */
 
 
 #include <QObject>
@@ -34,56 +34,56 @@
 
 class ObjectState : public QObject
 {
-	Q_OBJECT
+    Q_OBJECT
 public:
-	typedef int ObjectID_t;
-	typedef QVector3D Velocity;
-	typedef QVector3D Acceleration;
-	ObjectState(ObjectID_t id = 0, Qt::GlobalColor color = Qt::red);
+    typedef int ObjectID_t;
+    typedef QVector3D Velocity;
+    typedef QVector3D Acceleration;
+    ObjectState(ObjectID_t id = 0, Qt::GlobalColor color = Qt::red);
 #ifdef QT_GUI_LIB
-	virtual void draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected = true) = 0;
+    virtual void draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected = true) = 0;
 #endif
 
-	// Static state
-	ObjectID_t getId() const { return mId; }
-	void setId(ObjectID_t id, bool changeName = false);
-	QString getName() const { return mName; }
-	void setName(const QString& name) { mName = name; }
-	Qt::GlobalColor getColor() const { return mColor; }
-	void setColor(const Qt::GlobalColor color) { mColor = color; }
+    // Static state
+    ObjectID_t getId() const { return mId; }
+    void setId(ObjectID_t id, bool changeName = false);
+    QString getName() const { return mName; }
+    void setName(const QString& name) { mName = name; }
+    Qt::GlobalColor getColor() const { return mColor; }
+    void setColor(const Qt::GlobalColor color) { mColor = color; }
 
-	// Dynamic state
-	virtual PosPoint getPosition() const { return mPosition; }
-	virtual void setPosition(PosPoint &point);
-	virtual QTime getTime() const { return mPosition.getTime(); }
-	virtual void setTime(const QTime &time) { mPosition.setTime(time); }
-	virtual double getSpeed() const;
-	virtual void setSpeed(double value);
-	virtual Velocity getVelocity() const { return mVelocity; }
-	virtual void setVelocity(const Velocity &velocity) { mVelocity = velocity; }
-	virtual Acceleration getAcceleration() const { return mAcceleration; }
-	virtual void setAcceleration(const Acceleration &acceleration) { mAcceleration = acceleration; }
+    // Dynamic state
+    virtual PosPoint getPosition() const { return mPosition; }
+    virtual void setPosition(PosPoint &point);
+    virtual QTime getTime() const { return mPosition.getTime(); }
+    virtual void setTime(const QTime &time) { mPosition.setTime(time); }
+    virtual double getSpeed() const;
+    virtual void setSpeed(double value);
+    virtual Velocity getVelocity() const { return mVelocity; }
+    virtual void setVelocity(const Velocity &velocity) { mVelocity = velocity; }
+    virtual Acceleration getAcceleration() const { return mAcceleration; }
+    virtual void setAcceleration(const Acceleration &acceleration) { mAcceleration = acceleration; }
 
-	void setDrawStatusText(bool drawStatusText);
-	bool getDrawStatusText() const;
+    void setDrawStatusText(bool drawStatusText);
+    bool getDrawStatusText() const;
 
-	virtual void simulationStep(double dt_ms, PosType usePosType = PosType::simulated) = 0; // Take current state and simulate step forward for dt_ms milliseconds, update state accordingly
+    virtual void simulationStep(double dt_ms, PosType usePosType = PosType::simulated) = 0; // Take current state and simulate step forward for dt_ms milliseconds, update state accordingly
 
 signals:
-	void positionUpdated();
+    void positionUpdated();
 
 private:
-	// Static state
-	ObjectID_t mId;
-	QString mName;
-	Qt::GlobalColor mColor;
-	bool mDrawStatusText = true;
+    // Static state
+    ObjectID_t mId;
+    QString mName;
+    Qt::GlobalColor mColor;
+    bool mDrawStatusText = true;
 
 protected:
-	// Dynamic state
-	PosPoint mPosition;
-	Velocity mVelocity = {0.0, 0.0, 0.0}; // [m/s]
-	Acceleration mAcceleration = {0.0, 0.0, 0.0}; // [m/s²]
+    // Dynamic state
+    PosPoint mPosition;
+    Velocity mVelocity = {0.0, 0.0, 0.0}; // [m/s]
+    Acceleration mAcceleration = {0.0, 0.0, 0.0}; // [m/s²]
 };
 
 

--- a/objectstate.h
+++ b/objectstate.h
@@ -22,7 +22,6 @@
 
 #include <QObject>
 #include <QVector>
-#include <QVector3D>
 #include <QTime>
 #include <QString>
 #ifdef QT_GUI_LIB
@@ -37,8 +36,8 @@ class ObjectState : public QObject
     Q_OBJECT
 public:
     typedef int ObjectID_t;
-    typedef QVector3D Velocity;
-    typedef QVector3D Acceleration;
+    typedef struct {double x, y, z;} Velocity;
+    typedef struct {double x, y, z;} Acceleration;
     ObjectState(ObjectID_t id = 0, Qt::GlobalColor color = Qt::red);
 #ifdef QT_GUI_LIB
     virtual void draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected = true) = 0;
@@ -82,6 +81,7 @@ private:
 protected:
     // Dynamic state
     PosPoint mPosition;
+    double mSpeed = 0.0; // [m/s]
     Velocity mVelocity = {0.0, 0.0, 0.0}; // [m/s]
     Acceleration mAcceleration = {0.0, 0.0, 0.0}; // [m/s²]
 };

--- a/pospoint.cpp
+++ b/pospoint.cpp
@@ -20,7 +20,7 @@
 #include <cmath>
 
 PosPoint::PosPoint(double x, double y, double height, double roll, double pitch, double yaw, double speed,
-				   double radius, double sigma, QTime time, int id, bool drawLine, quint32 attributes, PosType type) :
+                   double radius, double sigma, QTime time, int id, bool drawLine, quint32 attributes, PosType type) :
     mX(x), mY(y), mHeight(height), mRoll(roll), mPitch(pitch), mYaw(yaw), mSpeed(speed),
     mRadius(radius), mSigma(sigma), mTime(time), mId(id), mDrawLine(drawLine),
     mAttributes(attributes), mType(type)

--- a/pospoint.cpp
+++ b/pospoint.cpp
@@ -20,7 +20,7 @@
 #include <cmath>
 
 PosPoint::PosPoint(double x, double y, double height, double roll, double pitch, double yaw, double speed,
-                   double radius, double sigma, qint32 time, int id, bool drawLine, quint32 attributes, PosType type) :
+				   double radius, double sigma, QTime time, int id, bool drawLine, quint32 attributes, PosType type) :
     mX(x), mY(y), mHeight(height), mRoll(roll), mPitch(pitch), mYaw(yaw), mSpeed(speed),
     mRadius(radius), mSigma(sigma), mTime(time), mId(id), mDrawLine(drawLine),
     mAttributes(attributes), mType(type)
@@ -108,7 +108,7 @@ void PosPoint::setXY(double x, double y)
     mY = y;
 }
 
-void PosPoint::setTime(const qint32 &time)
+void PosPoint::setTime(const QTime &time)
 {
     mTime = time;
 }
@@ -123,7 +123,7 @@ QString PosPoint::getInfo() const
     return mInfo;
 }
 
-qint32 PosPoint::getTime() const
+QTime PosPoint::getTime() const
 {
     return mTime;
 }

--- a/pospoint.h
+++ b/pospoint.h
@@ -21,6 +21,7 @@
 #include <QObject>
 #include <QPointF>
 #include <QString>
+#include <QTime>
 
 enum class PosType {
     simulated,
@@ -37,10 +38,10 @@ class PosPoint : public QObject
     Q_OBJECT
 public:
 
-    PosPoint(double x = 0, double y = 0, double height = 0, double roll = 0,
-             double pitch = 0, double yaw = 0, double speed = 0.5, double radius = 5.0,
-             double sigma = 0.0, qint32 time = 0,
-             int id = 0, bool drawLine = true, quint32 attributes = 0, PosType type = PosType::simulated);
+	PosPoint(double x = 0, double y = 0, double height = 0, double roll = 0,
+			 double pitch = 0, double yaw = 0, double speed = 0.5, double radius = 5.0,
+			 double sigma = 0.0, QTime time = QTime(),
+			 int id = 0, bool drawLine = true, quint32 attributes = 0, PosType type = PosType::simulated);
     PosPoint(const PosPoint &point);
 
     PosType getType() const;
@@ -57,7 +58,7 @@ public:
     double getSigma() const;
     QString getInfo() const;
     QColor getColor() const;
-    qint32 getTime() const;
+	QTime getTime() const;
     int getId() const;
     bool getDrawLine() const;
     quint32 getAttributes() const;
@@ -78,7 +79,7 @@ public:
     void setSigma(double sigma);
     void setInfo(const QString &info);
     void setColor(const QColor &color);
-    void setTime(const qint32 &time);
+	void setTime(const QTime &time);
     void setId(int id);
     void setDrawLine(bool drawLine);
     void setAttributes(quint32 attributes);
@@ -99,7 +100,7 @@ private:
     double mRadius;
     double mSigma;
     QString mInfo;
-    qint32 mTime;
+	QTime mTime;
     int mId;
     bool mDrawLine;
     quint32 mAttributes;

--- a/pospoint.h
+++ b/pospoint.h
@@ -38,10 +38,10 @@ class PosPoint : public QObject
     Q_OBJECT
 public:
 
-	PosPoint(double x = 0, double y = 0, double height = 0, double roll = 0,
-			 double pitch = 0, double yaw = 0, double speed = 0.5, double radius = 5.0,
-			 double sigma = 0.0, QTime time = QTime(),
-			 int id = 0, bool drawLine = true, quint32 attributes = 0, PosType type = PosType::simulated);
+    PosPoint(double x = 0, double y = 0, double height = 0, double roll = 0,
+             double pitch = 0, double yaw = 0, double speed = 0.5, double radius = 5.0,
+             double sigma = 0.0, QTime time = QTime(),
+             int id = 0, bool drawLine = true, quint32 attributes = 0, PosType type = PosType::simulated);
     PosPoint(const PosPoint &point);
 
     PosType getType() const;
@@ -58,7 +58,7 @@ public:
     double getSigma() const;
     QString getInfo() const;
     QColor getColor() const;
-	QTime getTime() const;
+    QTime getTime() const;
     int getId() const;
     bool getDrawLine() const;
     quint32 getAttributes() const;
@@ -79,7 +79,7 @@ public:
     void setSigma(double sigma);
     void setInfo(const QString &info);
     void setColor(const QColor &color);
-	void setTime(const QTime &time);
+    void setTime(const QTime &time);
     void setId(int id);
     void setDrawLine(bool drawLine);
     void setAttributes(quint32 attributes);
@@ -100,7 +100,7 @@ private:
     double mRadius;
     double mSigma;
     QString mInfo;
-	QTime mTime;
+    QTime mTime;
     int mId;
     bool mDrawLine;
     quint32 mAttributes;

--- a/vehiclestate.cpp
+++ b/vehiclestate.cpp
@@ -20,20 +20,20 @@
 #include <QDebug>
 
 VehicleState::VehicleState(ObjectState::ObjectID_t id, Qt::GlobalColor color)
-	: ObjectState (id, color)
+    : ObjectState (id, color)
 {
-	mTime = QTime();
+    mTime = QTime();
     mLength = 0.8;
     mWidth = 0.335;
 
     for (int i = 0; i < (int)PosType::_LAST_; i++)
         switch((PosType) i) {
-			case PosType::simulated: mPositionBySource[i].setType(PosType::simulated); break;
-			case PosType::fused: mPositionBySource[i].setType(PosType::fused); break;
-			case PosType::odom: mPositionBySource[i].setType(PosType::odom); break;
-			case PosType::IMU: mPositionBySource[i].setType(PosType::IMU); break;
-			case PosType::GNSS: mPositionBySource[i].setType(PosType::GNSS); break;
-			case PosType::UWB: mPositionBySource[i].setType(PosType::UWB); break;
+        case PosType::simulated: mPositionBySource[i].setType(PosType::simulated); break;
+        case PosType::fused: mPositionBySource[i].setType(PosType::fused); break;
+        case PosType::odom: mPositionBySource[i].setType(PosType::odom); break;
+        case PosType::IMU: mPositionBySource[i].setType(PosType::IMU); break;
+        case PosType::GNSS: mPositionBySource[i].setType(PosType::GNSS); break;
+        case PosType::UWB: mPositionBySource[i].setType(PosType::UWB); break;
         case PosType::_LAST_: qDebug() << "This should not have happended."; break;
 
         }
@@ -42,7 +42,7 @@ VehicleState::VehicleState(ObjectState::ObjectID_t id, Qt::GlobalColor color)
 
 void VehicleState::setPosition(PosPoint &point)
 {
-	mPositionBySource[(int)point.getType()] = point;
+    mPositionBySource[(int)point.getType()] = point;
 
     emit positionUpdated();
 }
@@ -69,6 +69,6 @@ void VehicleState::setAccelerometerXYZ(const std::array<float, 3> &accelerometer
 
 PosPoint VehicleState::getPosition(PosType type) const
 {
-	return mPositionBySource[(int)type];
+    return mPositionBySource[(int)type];
 }
 

--- a/vehiclestate.cpp
+++ b/vehiclestate.cpp
@@ -19,100 +19,32 @@
 #include "vehiclestate.h"
 #include <QDebug>
 
-VehicleState::VehicleState(int id, Qt::GlobalColor color)
+VehicleState::VehicleState(ObjectState::ObjectID_t id, Qt::GlobalColor color)
+	: ObjectState (id, color)
 {
-    mId = id;
-    mColor = color;
-    mName = "";
-    mName.sprintf("Vehicle %d", mId);
-    mTime = 0;
+	mTime = QTime();
     mLength = 0.8;
     mWidth = 0.335;
 
-
     for (int i = 0; i < (int)PosType::_LAST_; i++)
         switch((PosType) i) {
-            case PosType::simulated: mPosition[i].setType(PosType::simulated); break;
-            case PosType::fused: mPosition[i].setType(PosType::fused); break;
-            case PosType::odom: mPosition[i].setType(PosType::odom); break;
-            case PosType::IMU: mPosition[i].setType(PosType::IMU); break;
-            case PosType::GNSS: mPosition[i].setType(PosType::GNSS); break;
-            case PosType::UWB: mPosition[i].setType(PosType::UWB); break;
+			case PosType::simulated: mPositionBySource[i].setType(PosType::simulated); break;
+			case PosType::fused: mPositionBySource[i].setType(PosType::fused); break;
+			case PosType::odom: mPositionBySource[i].setType(PosType::odom); break;
+			case PosType::IMU: mPositionBySource[i].setType(PosType::IMU); break;
+			case PosType::GNSS: mPositionBySource[i].setType(PosType::GNSS); break;
+			case PosType::UWB: mPositionBySource[i].setType(PosType::UWB); break;
         case PosType::_LAST_: qDebug() << "This should not have happended."; break;
 
         }
 }
 
-int VehicleState::getId() const
-{
-    return mId;
-}
-
-void VehicleState::setId(int id, bool changeName)
-{
-    mId = id;
-
-    if (changeName) {
-        mName = "";
-        mName.sprintf("Vehicle %d", mId);
-    }
-}
-
-QString VehicleState::getName() const
-{
-    return mName;
-}
-
-void VehicleState::setName(QString name)
-{
-    mName = name;
-}
 
 void VehicleState::setPosition(PosPoint &point)
 {
-    mPosition[(int)point.getType()] = point;
+	mPositionBySource[(int)point.getType()] = point;
 
     emit positionUpdated();
-}
-
-Qt::GlobalColor VehicleState::getColor() const
-{
-    return mColor;
-}
-
-void VehicleState::setColor(Qt::GlobalColor color)
-{
-    mColor = color;
-}
-
-qint32 VehicleState::getTime() const
-{
-    return mTime;
-}
-
-void VehicleState::setTime(const qint32 &time)
-{
-    mTime = time;
-}
-
-double VehicleState::getSpeed() const
-{
-    return mSpeed;
-}
-
-void VehicleState::setSpeed(double value)
-{
-    mSpeed = value;
-}
-
-void VehicleState::setDrawStatusText(bool drawStatusText)
-{
-    mDrawStatusText = drawStatusText;
-}
-
-bool VehicleState::getDrawStatusText() const
-{
-    return mDrawStatusText;
 }
 
 std::array<float, 3> VehicleState::getGyroscopeXYZ() const
@@ -135,57 +67,8 @@ void VehicleState::setAccelerometerXYZ(const std::array<float, 3> &accelerometer
     mAccelerometerXYZ = accelerometerXYZ;
 }
 
-VehicleState::Velocity VehicleState::getVelocity() const
-{
-    return mVelocity;
-}
-
-void VehicleState::setVelocity(const VehicleState::Velocity &velocity)
-{
-    mVelocity = velocity;
-}
-
-double VehicleState::getMinAcceleration() const
-{
-    return mMinAcceleration;
-}
-
-void VehicleState::setMinAcceleration(double minAcceleration)
-{
-    mMinAcceleration = minAcceleration;
-}
-
-double VehicleState::getMaxAcceleration() const
-{
-    return mMaxAcceleration;
-}
-
-void VehicleState::setMaxAcceleration(double maxAcceleration)
-{
-    mMaxAcceleration = maxAcceleration;
-}
-
-double VehicleState::getLength() const
-{
-    return mLength;
-}
-
-void VehicleState::setLength(double length)
-{
-    mLength = length;
-}
-
-double VehicleState::getWidth() const
-{
-    return mWidth;
-}
-
-void VehicleState::setWidth(double width)
-{
-    mWidth = width;
-}
-
 PosPoint VehicleState::getPosition(PosType type) const
 {
-    return mPosition[(int)type];
+	return mPositionBySource[(int)type];
 }
+

--- a/vehiclestate.h
+++ b/vehiclestate.h
@@ -27,50 +27,31 @@
 #endif
 
 #include "pospoint.h"
+#include "objectstate.h"
 #include <math.h>
 
-class VehicleState : public QObject
+class VehicleState : public ObjectState
 {
     Q_OBJECT
 public:
-    VehicleState(int id = 0, Qt::GlobalColor color = Qt::red);
-#ifdef QT_GUI_LIB
-    virtual void draw(QPainter &painter, const QTransform &drawTrans, const QTransform &txtTrans, bool isSelected = true) = 0;
-#endif
-    struct Velocity {
-        double x, y, z;
-    };
+	VehicleState(ObjectID_t id = 0, Qt::GlobalColor color = Qt::red);
 
-    // Static state
-    int getId() const;
-    void setId(int id, bool changeName = false);
-    QString getName() const;
-    void setName(QString name);
-    Qt::GlobalColor getColor() const;
-    void setColor(Qt::GlobalColor color);
-    double getLength() const;
-    void setLength(double length);
-    double getWidth() const;
-    void setWidth(double width);
-    double getMinAcceleration() const;
-    void setMinAcceleration(double minAcceleration);
-    double getMaxAcceleration() const;
-    void setMaxAcceleration(double maxAcceleration);
+	// Static state
+	double getLength() const { return mLength; }
+	void setLength(double length) { mLength = length; }
+	double getWidth() const { return mWidth; }
+	void setWidth(double width) { mWidth = width; }
+	double getMinAcceleration() const { return mMinAcceleration; }
+	void setMinAcceleration(double minAcceleration) { mMinAcceleration = minAcceleration; }
+	double getMaxAcceleration() const { return mMaxAcceleration; }
+	void setMaxAcceleration(double maxAcceleration) { mMaxAcceleration = maxAcceleration; }
 
-    // Dynamic state
-    PosPoint getPosition(PosType type = PosType::simulated) const;
-    void setPosition(PosPoint &point);
-    qint32 getTime() const;
-    void setTime(const qint32 &time);
-    virtual double getSpeed() const;
-    void setSpeed(double value);
-    Velocity getVelocity() const;
-    void setVelocity(const Velocity &velocity);
-
-    void setDrawStatusText(bool drawStatusText);
-    bool getDrawStatusText() const;
-
-    virtual void simulationStep(double dt_ms, PosType usePosType = PosType::simulated) = 0; // Take current state and simulate step forward for dt_ms milliseconds, update state accordingly
+	// Dynamic state
+	virtual PosPoint getPosition(PosType type) const;
+	virtual PosPoint getPosition() const override { return getPosition(PosType::simulated); }
+	virtual void setPosition(PosPoint &point) override;
+	virtual QTime getTime() const override { return mTime; }
+	virtual void setTime(const QTime &time) override { mTime = time; }
 
     // For debugging and logging
     std::array<float, 3> getGyroscopeXYZ() const;
@@ -78,31 +59,21 @@ public:
     std::array<float, 3> getAccelerometerXYZ() const;
     void setAccelerometerXYZ(const std::array<float, 3> &accelerometerXYZ);
 
-signals:
-    void positionUpdated();
-
 private:
-    // Static state
-    int mId;
-    QString mName;
+	// Static state
     double mLength; // [m]
     double mWidth; // [m]
     // TODO: reasonable default values? set here or move?
     double mMinAcceleration = -5.0; // [m/s²]
-    double mMaxAcceleration = 3.0; // [m/s²]
-    Qt::GlobalColor mColor;
+	double mMaxAcceleration = 3.0; // [m/s²]
 
     // Dynamic state
-    PosPoint mPosition[(int)PosType::_LAST_];
+	PosPoint mPositionBySource[(int)PosType::_LAST_];
     PosPoint mApGoal;
-    qint32 mTime;
-    double mSpeed = 0.0; // [m/s]
-    Velocity mVelocity = {0.0, 0.0, 0.0}; // [m/s]
+	QTime mTime;
 
     std::array<float,3> mGyroscopeXYZ = std::array<float,3>({0.0, 0.0, 0.0}); // [deg/s]
     std::array<float,3> mAccelerometerXYZ = std::array<float,3>({0.0, 0.0, 0.0}); // [g]
-
-    bool mDrawStatusText = true;
 };
 
 #endif // VEHICLESTATE_H

--- a/vehiclestate.h
+++ b/vehiclestate.h
@@ -34,24 +34,24 @@ class VehicleState : public ObjectState
 {
     Q_OBJECT
 public:
-	VehicleState(ObjectID_t id = 0, Qt::GlobalColor color = Qt::red);
+    VehicleState(ObjectID_t id = 0, Qt::GlobalColor color = Qt::red);
 
-	// Static state
-	double getLength() const { return mLength; }
-	void setLength(double length) { mLength = length; }
-	double getWidth() const { return mWidth; }
-	void setWidth(double width) { mWidth = width; }
-	double getMinAcceleration() const { return mMinAcceleration; }
-	void setMinAcceleration(double minAcceleration) { mMinAcceleration = minAcceleration; }
-	double getMaxAcceleration() const { return mMaxAcceleration; }
-	void setMaxAcceleration(double maxAcceleration) { mMaxAcceleration = maxAcceleration; }
+    // Static state
+    double getLength() const { return mLength; }
+    void setLength(double length) { mLength = length; }
+    double getWidth() const { return mWidth; }
+    void setWidth(double width) { mWidth = width; }
+    double getMinAcceleration() const { return mMinAcceleration; }
+    void setMinAcceleration(double minAcceleration) { mMinAcceleration = minAcceleration; }
+    double getMaxAcceleration() const { return mMaxAcceleration; }
+    void setMaxAcceleration(double maxAcceleration) { mMaxAcceleration = maxAcceleration; }
 
-	// Dynamic state
-	virtual PosPoint getPosition(PosType type) const;
-	virtual PosPoint getPosition() const override { return getPosition(PosType::simulated); }
-	virtual void setPosition(PosPoint &point) override;
-	virtual QTime getTime() const override { return mTime; }
-	virtual void setTime(const QTime &time) override { mTime = time; }
+    // Dynamic state
+    virtual PosPoint getPosition(PosType type) const;
+    virtual PosPoint getPosition() const override { return getPosition(PosType::simulated); }
+    virtual void setPosition(PosPoint &point) override;
+    virtual QTime getTime() const override { return mTime; }
+    virtual void setTime(const QTime &time) override { mTime = time; }
 
     // For debugging and logging
     std::array<float, 3> getGyroscopeXYZ() const;
@@ -60,17 +60,17 @@ public:
     void setAccelerometerXYZ(const std::array<float, 3> &accelerometerXYZ);
 
 private:
-	// Static state
+    // Static state
     double mLength; // [m]
     double mWidth; // [m]
     // TODO: reasonable default values? set here or move?
     double mMinAcceleration = -5.0; // [m/s²]
-	double mMaxAcceleration = 3.0; // [m/s²]
+    double mMaxAcceleration = 3.0; // [m/s²]
 
     // Dynamic state
-	PosPoint mPositionBySource[(int)PosType::_LAST_];
+    PosPoint mPositionBySource[(int)PosType::_LAST_];
     PosPoint mApGoal;
-	QTime mTime;
+    QTime mTime;
 
     std::array<float,3> mGyroscopeXYZ = std::array<float,3>({0.0, 0.0, 0.0}); // [deg/s]
     std::array<float,3> mAccelerometerXYZ = std::array<float,3>({0.0, 0.0, 0.0}); // [g]

--- a/waypointfollower.h
+++ b/waypointfollower.h
@@ -67,7 +67,7 @@ public slots:
 
 private:
     PosPoint mFollowMePoint; // always in ENU
-    qint32 mFollowMeTimeStamp = 0;
+    QTime mFollowMeTimeStamp;
     const unsigned mCountdown_ms = 1000;
     QTimer mSensorHeartbeatTimer;
     bool mSensorHeartbeat;


### PR DESCRIPTION
Placed all the general functionality such as name, id, draw etc. in ObjectState. Made VehicleState inherit from that, but override stuff so the functionality is _nearly_ the same, save for the below.

The one change which is more of a change is the swap from qint32 to QTime for representing timestamps. It seems any time a qint32 was used this way, it was always converted into a QTime which seemed unnecessarily hard to read.

I have handled this change in SafetyZone, and a PR is forthcoming soon in that repo as well.